### PR TITLE
test UNC paths on Win32

### DIFF
--- a/t/Path.t
+++ b/t/Path.t
@@ -2,7 +2,7 @@
 
 use strict;
 
-use Test::More tests => 131;
+use Test::More tests => 133;
 use Config;
 
 BEGIN {
@@ -321,17 +321,16 @@ else {
 }
 
 SKIP: {
-    skip "This is not a MSWin32 platform", 1
+    skip "This is not a MSWin32 platform", 3
         unless $^O eq 'MSWin32';
 
-    my $UNC_path_taint = $ENV{PERL_FILE_PATH_UNC_TESTDIR};
-    skip "PERL_FILE_PATH_UNC_TESTDIR environment variable not set", 1
-        unless defined($UNC_path_taint);
-
-    my ($UNC_path) = ($UNC_path_taint =~ m{^([/\\]{2}\w+[/\\]\w+[/\\]\w+)$});
-
-    skip "PERL_FILE_PATH_UNC_TESTDIR environment variable does not point to a directory", 1
-        unless -d $UNC_path;
+    my $UNC_path = catdir(getcwd(), $tmp_base, 'uncdir');
+    #dont compute a SMB path with $ENV{COMPUTERNAME}, since SMB may be turned off
+    #firewalled, disabled, blocked, or no NICs are on and there the PC has no
+    #working TCPIP stack, \\?\ will always work
+    $UNC_path = '\\\\?\\'.$UNC_path;
+    is(mkpath($UNC_path), 1, 'mkpath on Win32 UNC path returns made 1 dir');
+    ok(-d $UNC_path, 'mkpath on Win32 UNC path made dir');
 
     my $removed = rmtree($UNC_path);
     cmp_ok($removed, '>', 0, "removed $removed entries from $UNC_path");


### PR DESCRIPTION
This patch proves RT #70657 is not reproducable and is therefore rejected.