### PR TITLE
better build product git ignoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ blib
 Makefile
 META.json
 pm_to_blib
+MYMETA.yml
+MYMETA.json
+test-*

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,7 +35,7 @@ WriteMakefile(
         @extra_prereq,
     },
     clean => {
-        FILES => 'cover_db',
+        FILES => 'cover_db test-*',
     },
     repository  => {
       url  => 'git://github.com/dland/File-Path',


### PR DESCRIPTION
If a .t fails early, there wont be cleanup and a test-* folder will be
left over.