### PR TITLE
remove English.pm

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,6 @@ WriteMakefile(
         'Cwd'            => 0,
         'File::Basename' => 0,
         'File::Spec'     => 0,
-        'English'        => 0,
         ( eval { $] < 5.006 } ? ( 'Symbol' => 0 ) : () ),
     },
     clean => {

--- a/t/Path.t
+++ b/t/Path.t
@@ -628,7 +628,7 @@ unable to map $max_group to a gid, group ownership not changed: .* at \S+ line \
 }
 
 SKIP: {
-    skip 'Test::Output not available', 17
+    skip 'Test::Output not available', 18
         unless $has_Test_Output;
 
     SKIP: {


### PR DESCRIPTION
English.pm is only a minor readability improvement, and for people used
to perl's globals is actively confusing.  Additionally,
$OLD_PERL_VERSION was only introduced in perl 5.20, so it is useless for
how it was being used.

This addresses @ribasushi's comments on f9d871272193f2a978cce992d2ddecb6791b19cb.