### PR TITLE
use constants rather than lexicals for OS based checks

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,6 @@ WriteMakefile(
         'Cwd'            => 0,
         'File::Basename' => 0,
         'File::Spec'     => 0,
-        'English'        => 0,
         ( eval { $] < 5.006 } ? ( 'Symbol' => 0 ) : () ),
     },
     clean => {

--- a/t/Path.t
+++ b/t/Path.t
@@ -628,7 +628,7 @@ unable to map $max_group to a gid, group ownership not changed: .* at \S+ line \
 }
 
 SKIP: {
-    skip 'Test::Output not available', 17
+    skip 'Test::Output not available', 18
         unless $has_Test_Output;
 
     SKIP: {


### PR DESCRIPTION
The OS can't change, so it's better to use constants to check it.  This
allows perl to optimize away the code for other operating systems.

This includes the commits from #19.