### PR TITLE
make_path, remove_tree:  Die on unrecognized options.

### DIFF
--- a/lib/File/Path.pm
+++ b/lib/File/Path.pm
@@ -96,7 +96,24 @@ sub mkpath {
         $arg->{mode} = defined $mode ? $mode : oct '777';
     }
     else {
+        my %args_permitted = map { $_ => 1 } ( qw|
+            chmod
+            error
+            group
+            mask
+            mode
+            owner
+            uid
+            user
+            verbose
+        | );
+        my @bad_args = ();
         $arg = pop @_;
+        for my $k (sort keys %{$arg}) {
+            push @bad_args, $k unless $args_permitted{$k};
+        }
+        _croak("Unrecognized option(s) passed to make_path(): @bad_args")
+            if @bad_args;
         $arg->{mode} = delete $arg->{mask} if exists $arg->{mask};
         $arg->{mode} = oct '777' unless exists $arg->{mode};
         ${ $arg->{error} } = [] if exists $arg->{error};
@@ -239,7 +256,20 @@ sub rmtree {
         }
     }
     else {
+        my %args_permitted = map { $_ => 1 } ( qw|
+            error
+            keep_root
+            result
+            safe
+            verbose
+        | );
+        my @bad_args = ();
         $arg = pop @_;
+        for my $k (sort keys %{$arg}) {
+            push @bad_args, $k unless $args_permitted{$k};
+        }
+        _croak("Unrecognized option(s) passed to remove_tree(): @bad_args")
+            if @bad_args;
         ${ $arg->{error} }  = [] if exists $arg->{error};
         ${ $arg->{result} } = [] if exists $arg->{result};
         $paths = [@_];

--- a/t/Path.t
+++ b/t/Path.t
@@ -3,7 +3,7 @@
 
 use strict;
 
-use Test::More tests => 159;
+use Test::More tests => 161;
 use Config;
 use Fcntl ':mode';
 
@@ -736,6 +736,36 @@ cannot remove directory for [^:]+: .* at \1 line \2},
         "mkdir $dir\nmkdir $dir2\n",
         'make_path verbose with final hashref'
     );
+
+    {
+        local $@;
+        eval {
+            @created = make_path(
+                $dir,
+                $dir2,
+                { verbose => 1, mode => 0711, foo => 1, bar => 1 }
+            );
+        };
+        like($@,
+            qr/Unrecognized option\(s\) passed to make_path\(\):.*?bar.*?foo/,
+            'make_path with final hashref failed due to unrecognized options'
+        );
+    }
+
+    {
+        local $@;
+        eval {
+            @created = remove_tree(
+                $dir,
+                $dir2,
+                { verbose => 1, foo => 1, bar => 1 }
+            );
+        };
+        like($@,
+            qr/Unrecognized option\(s\) passed to remove_tree\(\):.*?bar.*?foo/,
+            'remove_tree with final hashref failed due to unrecognized options'
+        );
+    }
 
     stdout_is(
         sub {


### PR DESCRIPTION
Validate each key passed in a final hashref argument to either make_path() or
remove_tree().  Assemble list of unrecognized options and die if that list has
non-zero elements, listing each bad option.

For: https://rt.cpan.org/Ticket/Display.html?id=70257