### PR TITLE
Add explicit tests for internal sub _error().

### DIFF
--- a/t/Path.t
+++ b/t/Path.t
@@ -3,7 +3,7 @@
 
 use strict;
 
-use Test::More tests => 159;
+use Test::More tests => 170;
 use Config;
 use Fcntl ':mode';
 
@@ -849,3 +849,88 @@ is(
     $expect,
     "Windows path unixified as expected"
 );
+
+{
+    my ($x, $message, $object, $expect, $rv, $arg, $error);
+    my ($k, $v, $second_error, $third_error);
+    local $! = 2;
+    $x = $!;
+
+    $message = 'message in a bottle';
+    $object = '/path/to/glory';
+    $expect = "$message for $object: $x";
+    $rv = _run_for_warning( sub {
+        File::Path::_error(
+            {},
+            $message,
+            $object
+        );
+    } );
+    like($rv, qr/^$expect/,
+        "no \$arg->{error}: defined 2nd and 3rd args: got expected error message");
+
+    $object = undef;
+    $expect = "$message: $x";
+    $rv = _run_for_warning( sub {
+        File::Path::_error(
+            {},
+            $message,
+            $object
+        );
+    } );
+    like($rv, qr/^$expect/,
+        "no \$arg->{error}: defined 2nd arg; undefined 3rd arg: got expected error message");
+
+    $message = 'message in a bottle';
+    $object = undef;
+    $expect = "$message: $x";
+    $arg = { error => \$error };
+    File::Path::_error(
+        $arg,
+        $message,
+        $object
+    );
+    is(ref($error->[0]), 'HASH',
+        "first element of array inside \$error is hashref");
+    ($k, $v) = %{$error->[0]};
+    is($k, '', 'key of hash is empty string, since 3rd arg was undef');
+    is($v, $expect, "value of hash is 2nd arg: $message");
+
+    $message = '';
+    $object = '/path/to/glory';
+    $expect = "$message: $x";
+    $arg = { error => \$second_error };
+    File::Path::_error(
+        $arg,
+        $message,
+        $object
+    );
+    is(ref($second_error->[0]), 'HASH',
+        "first element of array inside \$second_error is hashref");
+    ($k, $v) = %{$second_error->[0]};
+    is($k, $object, "key of hash is '$object', since 3rd arg was defined");
+    is($v, $expect, "value of hash is 2nd arg: $message");
+
+    $message = '';
+    $object = undef;
+    $expect = "$message: $x";
+    $arg = { error => \$third_error };
+    File::Path::_error(
+        $arg,
+        $message,
+        $object
+    );
+    is(ref($third_error->[0]), 'HASH',
+        "first element of array inside \$third_error is hashref");
+    ($k, $v) = %{$third_error->[0]};
+    is($k, '', "key of hash is empty string, since 3rd arg was undef");
+    is($v, $expect, "value of hash is 2nd arg: $message");
+}
+
+sub _run_for_warning {
+    my $coderef = shift;
+    my $warn;
+    local $SIG{__WARN__} = sub { $warn = shift };
+    &$coderef;
+    return $warn;
+}


### PR DESCRIPTION
Most of the instances in which File::Path::_error() was hitherto exercised fell
into the blocks only run by root.  Hence, most of the branches and conditions
within that subroutine showed up as uncovered during coverage analysis, and it's
difficult for mere mortal users to get an idea of how the sub works.  (And
running Devel::Cover as root does not sound like a good idea.)

Add a block of tests which exercise all the nooks and crannies of
File::Path_error().