### PR TITLE
In POD, check $err is defined before dereferencing

### DIFF
--- a/lib/File/Path.pm
+++ b/lib/File/Path.pm
@@ -828,7 +828,7 @@ encountered the diagnostic key will be empty.
 An example usage looks like:
 
   remove_tree( 'foo/bar', 'bar/rat', {error => \my $err} );
-  if (@$err) {
+  if ($err && @$err) {
       for my $diag (@$err) {
           my ($file, $message) = %$diag;
           if ($file eq '') {


### PR DESCRIPTION
I tried running the old error checking code for make_path, and it didn't work as written (no error was generated, but $err was not defined as an arrayref either).