### PR TITLE
skip the Win32 UNC tests on Windows 2000 and earlier

### DIFF
--- a/t/Path_win32.t
+++ b/t/Path_win32.t
@@ -7,6 +7,9 @@ use Cwd;
 use File::Spec::Functions;
 
 plan skip_all  => 'not win32' unless $^O eq 'MSWin32';
+my ($ignore, $major, $minor, $build, $id) = Win32::GetOSVersion();
+plan skip_all  => "WinXP or later"
+     unless $id >= 2 && ($major > 5 || $major == 5 && $minor >= 1);
 plan tests     => 3;
 
 my $tmp_base = catdir(


### PR DESCRIPTION
Windows 2000 won't resolve "." off the current directory when that
directory is a UNC path, since it's such an old operating system,
skip the test rather than rewriting File::Path.

This test has been causing failures for non-threaded perls on George Greer's Win32 perl smoker since it was added, I only recently had a chance to track it down.

See https://rt.perl.org/Ticket/Display.html?id=127760 for more details.