### PR TITLE
Don't hardcode ENOENT.

### DIFF
--- a/t/Path.t
+++ b/t/Path.t
@@ -8,6 +8,7 @@ use Config;
 use Fcntl ':mode';
 use lib 't/';
 use FilePathTest;
+use Errno qw(:POSIX);
 
 BEGIN {
     use_ok('Cwd');
@@ -656,7 +657,7 @@ is(
 {
     my ($x, $message, $object, $expect, $rv, $arg, $error);
     my ($k, $v, $second_error, $third_error);
-    local $! = 2;
+    local $! = ENOENT;
     $x = $!;
 
     $message = 'message in a bottle';


### PR DESCRIPTION
The attached patch, provided by Pino Toscano of the Debian project, fixes a
test failure on GNU/Hurd because on that platform, ENOENT is not 2. This fixes
a regression between 2.11 and 2.12.  Suggested by Dominic Hargreaves.

For: https://rt.cpan.org/Ticket/Display.html?id=117620