### PR TITLE
Remove superfluous assignment to '$arg{perm}'.

### DIFF
--- a/lib/File/Path.pm
+++ b/lib/File/Path.pm
@@ -312,7 +312,7 @@ sub rmtree {
         push @clean_path, $p;
     }
 
-    @{$arg}{qw(device inode perm)} = ( lstat $arg->{cwd} )[ 0, 1 ] or do {
+    @{$arg}{qw(device inode)} = ( lstat $arg->{cwd} )[ 0, 1 ] or do {
         _error( $arg, "cannot stat initial working directory", $arg->{cwd} );
         return 0;
     };


### PR DESCRIPTION
In this instance of an invocation of 'lstat' -- unlike the other instances
later on within _rmtree() -- we are only consulting the first two elements in
the list returned by that builtin function.  Hence, we are only assigning to
'device' and 'inode'; 'perm' will always be undefined.  Within _rmtree()
'$arg{perm}' is never consulted.  Hence, the assignment is superfluous and
should be removed.