### PR TITLE
Don't mix options passed to remove_tree() with internally generated p…

### DIFF
--- a/lib/File/Path.pm
+++ b/lib/File/Path.pm
@@ -1158,6 +1158,8 @@ Contributors to File::Path, in alphabetical order.
 
 =item <F<bulkdd@cpan.org>>
 
+=item Charlie Gonzalez <F<itcharlie@cpan.org>>
+
 =item Craig A. Berry <F<craigberry@mac.com>>
 
 =item Richard Elberger <F<riche@cpan.org>>
@@ -1175,7 +1177,7 @@ Contributors to File::Path, in alphabetical order.
 =head1 COPYRIGHT
 
 This module is copyright (C) Charles Bailey, Tim Bunce, David Landgren,
-James Keenan, and Richard Elberger 1995-2015. All rights reserved.
+James Keenan and Richard Elberger 1995-2017. All rights reserved.
 
 =head1 LICENSE
 


### PR DESCRIPTION
…arameters.

Within remove_tree(), we'll use $arg to hold values passed in the options hash
and $data to hold (a) those values once validated; and (b) internally generated
parameters.  This should permit re-use of an options hash as the final
argument to remove_tree().

Write tests.

For https://rt.cpan.org/Ticket/Display.html?id=117019.

For consistency, we'll apply the same distinction between $arg and $data
within make_path() -- or, more precisely, inside mkpath() where make_path() is
implemented.  mkpath() did not suffer from the problem described in RT 117019
because each of its internally-assigned parameters is also a valid key in its
options hash.