### PR TITLE
_mkpath(), _rmtree(): Change $arg to $data.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl extension File::Path.
 
-2.12_001 2017-03-12
+2.12_002 2017-03-12
     - GH#41 RT 117019 Fixed File::Path::remove_tree option hash is auto
                       populated and cannot be reused
     - GH#40 Unskip in path root t

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-This file is the README for File::Path version 2.09
+This file is the README for File::Path version 2.12_002
 [![Build Status](https://travis-ci.org/rpcme/File-Path.svg?branch=master)](https://travis-ci.org/rpcme/File-Path)
 [![CPAN version](https://badge.fury.io/pl/File-Path.svg)](http://badge.fury.io/pl/File-Path)
 


### PR DESCRIPTION
In version 2.12_002, we renamed $arg within mkpath() and rmtree() to $data so
as to draw a better distinction between arguments passed to those functions
and the sets of parameters which those functions set up internally.  Some of
those internal parameters are determined from the arguments passed to the
function; some are set purely internally.

mkpath() internally calls _mkpath(), potentially recursively.  Similarly
rmtree() internally calls _rmtree(), potentially recursively.  For
consistency, let's use $data in both pairs of functions.

Changes:  Correct inaccurate version number.