### PR TITLE
Wrong directory tested with '-d' in two tests; fix.

### DIFF
--- a/t/Path.t
+++ b/t/Path.t
@@ -752,9 +752,9 @@ is(
 
     File::Path::remove_tree($next_deepest, $opts);
     ok(! $warn, "CPAN 117019: No warning thrown when re-using \$opts");
-    ok(! -d $deepest, "directory '$next_deepest' removed, as expected");
+    ok(! -d $next_deepest, "directory '$next_deepest' removed, as expected");
 
     File::Path::remove_tree($least_deep, $opts);
     ok(! $warn, "CPAN 117019: No warning thrown when re-using \$opts");
-    ok(! -d $deepest, "directory '$least_deep' removed, as expected");
+    ok(! -d $least_deep, "directory '$least_deep' removed, as expected");
 }


### PR DESCRIPTION
In the course of working on other known problems, I recognized that I had incorrectly copied-and-pasted two variables when writing tests recently.  Consequently, the test results were misleading.  This should fix the problem.