### PR TITLE
rt.cpan.org # 120645: Clean up directories created during running of t/Path_root.t.

### DIFF
--- a/t/Path_root.t
+++ b/t/Path_root.t
@@ -9,7 +9,7 @@ use File::Spec::Functions;
 
 my $prereq = prereq();
 plan skip_all  => $prereq if defined $prereq;
-plan tests     => 9;
+plan tests     => 11;
 
 my $pwent = max_u();
 my $grent = max_g();
@@ -80,6 +80,15 @@ is($dir_gid, $max_gid, "... owned by group $max_gid");
     qr{unable to map $max_group to a gid, group ownership not changed:}s,
     "created a directory not owned by $max_user:$max_group...",
   );
+}
+
+{
+    # cleanup
+    my $x;
+    my $opts = { error => \$x };
+    remove_tree($tmp_base, $opts);
+    ok(! -d $tmp_base, "directory '$tmp_base' removed, as expected");
+    is(scalar(@{$x}), 0, "no error messages using remove_tree() with \$opts");
 }
 
 sub max_u {


### PR DESCRIPTION
This pull request addresses the problem identified in:

https://rt.cpan.org/Ticket/Display.html?id=120645

It is independent of the other pull requests I have recently filed.  Since it addresses a bug rather than simply adding tests, it should take priority over those other p.r.s.

Thank you very much.